### PR TITLE
Add wait step for SecurityGroup update in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,22 @@ jobs:
     - name: Open SecurityGroup
       run: aws ec2 authorize-security-group-ingress --group-id ${{ secrets.EC2_SECURITY_GROUP_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
 
+    - name: Wait for SecurityGroup to be updated
+      run: |
+        while true; do
+          STATE=$(aws ec2 describe-security-groups \
+            --group-ids ${{ secrets.EC2_SECURITY_GROUP_ID }} \
+            --query 'SecurityGroups[0].IpPermissions[?ToPort==`22`].IpRanges[?CidrIp==`'${{ steps.ip.outputs.ipv4 }}/32'`]' \
+            --output text)
+          echo "Current SecurityGroup state: $STATE"
+          if [ "$STATE" != "" ]; then
+            echo "SecurityGroup is now updated!"
+            break
+          fi
+          echo "Waiting for SecurityGroup to be updated..."
+          sleep 15
+        done
+
     - name: Remove all files in target path
       uses: appleboy/ssh-action@master
       with:


### PR DESCRIPTION
Introduce a wait step in the deployment workflow to ensure the SecurityGroup update completes before proceeding. This enhances the reliability of the deployment process.